### PR TITLE
Feature/exit codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn-error.log

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
-const debug = require('debug')('meta-loop');
+const debug = require('debug')('@essential-projects/meta-loop');
 const getMetaFile = require('get-meta-file');
-const loop = require('loop');
+const loop = require('@essential-projects/loop');
 const path = require('path');
 const util = require('util');
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
-const debug = require('debug')('@essential-projects/meta-loop');
+const debug = require('debug')('meta-loop');
 const getMetaFile = require('get-meta-file');
-const loop = require('@essential-projects/loop');
+const loop = require('loop');
 const path = require('path');
 const util = require('util');
 
@@ -13,10 +13,13 @@ module.exports = function (command) {
   const projects = meta.projects;
   const folders = Object.keys(projects).map((folder) => { return path.resolve(folder); });
 
+  const exitOnError = process.argv.indexOf('--exit-on-error') >= 0;
+  const exitOnAggregatedError = process.argv.indexOf('--exit-on-aggregated-error') >= 0;
+
   folders.unshift(process.cwd());
 
   // remove loop flags, and let loop pick them up from process.env
-  ['--exclude', '--exclude-only', '--include', '--include-only', '--exit-on-error', '--exit-on-aggregated-errors'].forEach((flag) => {
+  ['--exclude', '--exclude-only', '--include', '--include-only'].forEach((flag) => {
     const flagIndex = command.indexOf(flag);
     if (flagIndex > -1) {
       command = command.substring(0, flagIndex);
@@ -25,6 +28,13 @@ module.exports = function (command) {
 
   loop({
     command: command,
-    directories: folders
+    directories: folders,
+    exitOnError: exitOnError,
+    exitOnAggregatedError: exitOnAggregatedError,
+  }, (errorOccured) => {
+    if (exitOnAggregatedError && errorOccured) {
+      console.log('an error occured during loop execution - exiting process');
+      process.exit(1);
+    }
   });
 };

--- a/index.js
+++ b/index.js
@@ -31,10 +31,5 @@ module.exports = function (command) {
     directories: folders,
     exitOnError: exitOnError,
     exitOnAggregatedError: exitOnAggregatedError,
-  }, (errorOccured) => {
-    if (exitOnAggregatedError && errorOccured) {
-      console.log('an error occured during loop execution - exiting process');
-      process.exit(1);
-    }
   });
 };

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (command) {
   folders.unshift(process.cwd());
 
   // remove loop flags, and let loop pick them up from process.env
-  ['--exclude', '--exclude-only', '--include', '--include-only'].forEach((flag) => {
+  ['--exclude', '--exclude-only', '--include', '--include-only', '--exit-on-error', '--exit-on-aggregated-errors'].forEach((flag) => {
     const flagIndex = command.indexOf(flag);
     if (flagIndex > -1) {
       command = command.substring(0, flagIndex);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "module to locate a meta project's .meta file, and execute a provided command within the meta project's and all child projects' directories",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "debug": "^2.6.3",
     "get-meta-file": "^0.0.5",
-    "loop": "^3.0.1"
+    "@essential-projects/loop": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@essential-projects/meta-loop",
+  "publishConfig": {
+    "registry": "https://www.npmjs.com"
+  },
   "version": "0.0.5",
   "description": "module to locate a meta project's .meta file, and execute a provided command within the meta project's and all child projects' directories",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@essential-projects/meta-loop",
+  "name": "meta-loop",
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
@@ -22,6 +22,6 @@
   "dependencies": {
     "debug": "^2.6.3",
     "get-meta-file": "^0.0.5",
-    "@essential-projects/loop": "^3.0.5"
+    "loop": "^3.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "meta-loop",
+  "name": "@essential-projects/meta-loop",
   "version": "0.0.5",
   "description": "module to locate a meta project's .meta file, and execute a provided command within the meta project's and all child projects' directories",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "module to locate a meta project's .meta file, and execute a provided command within the meta project's and all child projects' directories",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   "dependencies": {
     "debug": "^2.6.3",
     "get-meta-file": "^0.0.5",
-    "@essential-projects/loop": "^3.0.1"
+    "@essential-projects/loop": "^3.0.5"
   }
 }


### PR DESCRIPTION
This adds two options `exit-on-error` and `exit-on-aggregated-error`.

`exit-on-error` directly cancels everything with `process.exit(1)` as soon as an error occurs on a sub command.

`exit-on-aggregated-error` waits until all sub commands have run and then exits with `process.exit(1)`.

I added the options, because without them I didn't find any way to have the exit code on the original `meta` call reflect that errors occured on one of the commands.

This PR also involves PRs for `meta-exec`, `meta` and `loop` itself.

I didn't clean up the commit history and I had to do some version changes during the process to test the changes on my local setup.

I'll gladly clean up everything as soon as you reviewed it, but would like to keep it until then for testing purposes. If you want I can also provide you with a test setup if that might be an issue (wasn't easy for me ;).