### PR TITLE
feat: support for subsets in .meta project file

### DIFF
--- a/bin/meta-exec
+++ b/bin/meta-exec
@@ -5,7 +5,7 @@ const metaLoop = require('../');
 if (!process.argv[2] || process.argv[2] === '--help') return console.log(`\n  usage:\n\n    meta exec <command>\n`);
 
 let commandIndex = process.argv[2] === 'blank' ? 3 : 2;
-let command = process.argv[commandIndex]
+let command = `\"${process.argv[commandIndex]}\"`
 if (process.argv.length > commandIndex) {
   for (let i=commandIndex + 1; i < process.argv.length; i++) {
     command+= ` ${process.argv[i]}`;

--- a/bin/meta-exec
+++ b/bin/meta-exec
@@ -4,6 +4,11 @@ const metaLoop = require('../');
 
 if (!process.argv[2] || process.argv[2] === '--help') return console.log(`\n  usage:\n\n    meta exec <command>\n`);
 
-let command = process.argv[2] === 'blank' ? process.argv[3] : process.argv[2];
-
+let commandIndex = process.argv[2] === 'blank' ? 3 : 2;
+let command = process.argv[commandIndex]
+if (process.argv.length > commandIndex) {
+  for (let i=commandIndex + 1; i < process.argv.length; i++) {
+    command+= ` ${process.argv[i]}`;
+  }
+}
 metaLoop(command);

--- a/bin/meta-loop
+++ b/bin/meta-loop
@@ -5,7 +5,7 @@ const metaLoop = require('../');
 if (!process.argv[2] || process.argv[2] === '--help') return console.log(`\n  usage:\n\n    meta exec <command>\n`);
 
 let commandIndex = process.argv[2] === 'blank' ? 3 : 2;
-let command = process.argv[commandIndex]
+let command = `\"${process.argv[commandIndex]}\"`
 if (process.argv.length > commandIndex) {
   for (let i=commandIndex + 1; i < process.argv.length; i++) {
     command+= ` ${process.argv[i]}`;

--- a/bin/meta-loop
+++ b/bin/meta-loop
@@ -4,6 +4,11 @@ const metaLoop = require('../');
 
 if (!process.argv[2] || process.argv[2] === '--help') return console.log(`\n  usage:\n\n    meta exec <command>\n`);
 
-let command = process.argv[2] === 'blank' ? process.argv[3] : process.argv[2];
-
+let commandIndex = process.argv[2] === 'blank' ? 3 : 2;
+let command = process.argv[commandIndex]
+if (process.argv.length > commandIndex) {
+  for (let i=commandIndex + 1; i < process.argv.length; i++) {
+    command+= ` ${process.argv[i]}`;
+  }
+}
 metaLoop(command);

--- a/index.js
+++ b/index.js
@@ -43,13 +43,14 @@ module.exports = function(command) {
         console.log(`WARNING: subset \'${subset}\' not found in projects.`);
       }
     }
-    command = command.split(' ')[0];
   } else {
     projects = recursiveSearch(projects);
     folders = projects.map(folder => {
       return path.resolve(folder);
     });
   }
+
+  command = command.substring(1).split('"')[0];
 
   const exitOnError = process.argv.indexOf('--exit-on-error') >= 0;
   const exitOnAggregateError = process.argv.indexOf('--exit-on-aggregated-error') >= 0;

--- a/index.js
+++ b/index.js
@@ -50,7 +50,11 @@ module.exports = function(command) {
     });
   }
 
-  command = command.substring(1).split('"')[0];
+  //meta loop is commonly invoked using the module entrypoint
+  //without options
+  if (command.startsWith('"')) {
+    command = command.substring(1).split('"')[0];
+  }
 
   const exitOnError = process.argv.indexOf('--exit-on-error') >= 0;
   const exitOnAggregateError = process.argv.indexOf('--exit-on-aggregated-error') >= 0;


### PR DESCRIPTION
Support for nesting .meta projects in subsets

explainer/demo - https://vimeo.com/523541918 



![image](https://user-images.githubusercontent.com/22084334/111086341-d8cc4480-84d8-11eb-9264-6bade2d87bca.png)

usage:

include all: `meta exec "ls -la"`
or apps only: `meta exec "ls -la" --subsets /apps`
or just the web apps and services: `meta exec "ls -la" --subsets /apps/web,/services`