### PR TITLE
feat: support switch to allow for skipping of meta dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,6 @@ module.exports = function (command) {
     folders.unshift(process.cwd());
   }
 
-  console.log('folders: ', folders);
-
   // remove loop flags, and let loop pick them up from process.env
   ['--exclude', '--exclude-only', '--include', '--include-only', '--parallel'].forEach((flag) => {
     const flagIndex = command.indexOf(flag);

--- a/index.js
+++ b/index.js
@@ -18,8 +18,13 @@ module.exports = function (command) {
 
   const exitOnError = process.argv.indexOf('--exit-on-error') >= 0;
   const exitOnAggregateError = process.argv.indexOf('--exit-on-aggregated-error') >= 0;
+  const skipMeta = process.argv.indexOf('--skip-meta') >= 0;
 
-  folders.unshift(process.cwd());
+  if (!skipMeta) {
+    folders.unshift(process.cwd());
+  }
+
+  console.log('folders: ', folders);
 
   // remove loop flags, and let loop pick them up from process.env
   ['--exclude', '--exclude-only', '--include', '--include-only', '--parallel'].forEach((flag) => {


### PR DESCRIPTION
We recently discovered a use case which requires us to run `npm install` on all of our modules _except_ meta.  This isn't currently supported, so I figured I'd throw in a PR to support our use case.